### PR TITLE
add configurable option to exclude source files from being processed

### DIFF
--- a/ResXManager.Model/ResXManager.Model.csproj
+++ b/ResXManager.Model/ResXManager.Model.csproj
@@ -184,6 +184,7 @@
     <Compile Include="..\Version.cs">
       <Link>Version.cs</Link>
     </Compile>
+    <Compile Include="SourceFileExclusionFilterConfiguration.cs" />
     <Compile Include="CodeReferenceConfiguration.cs" />
     <Compile Include="ColumnKind.cs" />
     <Compile Include="Configuration.cs" />

--- a/ResXManager.Model/SourceFileExclusionFilterConfiguration.cs
+++ b/ResXManager.Model/SourceFileExclusionFilterConfiguration.cs
@@ -1,0 +1,134 @@
+﻿namespace tomenglertde.ResXManager.Model
+{
+    using System;
+    using System.Collections.ObjectModel;
+    using System.ComponentModel;
+    using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Diagnostics.Contracts;
+    using System.Runtime.Serialization;
+
+    using JetBrains.Annotations;
+
+    using TomsToolbox.ObservableCollections;
+
+    [DataContract]
+    public class SourceFileExclusionFilterConfigurationItem : INotifyPropertyChanged
+    {
+        private string _expression;
+
+        [DataMember]
+        public string Expression
+        {
+            get
+            {
+                return _expression;
+            }
+            set
+            {
+                SetProperty(ref _expression, value, nameof(Expression));
+            }
+        }
+
+        #region INotifyPropertyChanged implementation
+
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        [NotifyPropertyChangedInvocator]
+        private void SetProperty<T>(ref T backingField, T value, [NotNull] string propertyName)
+        {
+            Contract.Requires(!string.IsNullOrEmpty(propertyName));
+
+            if (Equals(backingField, value))
+                return;
+
+            backingField = value;
+
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        #endregion
+    }
+
+    [KnownType(typeof(SourceFileExclusionFilterConfigurationItem))]
+    [DataContract]
+    [TypeConverter(typeof(JsonSerializerTypeConverter<SourceFileExclusionFilterConfiguration>))]
+    public class SourceFileExclusionFilterConfiguration
+    {
+        private ObservableCollection<SourceFileExclusionFilterConfigurationItem> _items;
+        private ObservablePropertyChangeTracker<SourceFileExclusionFilterConfigurationItem> _changeTracker;
+
+        [DataMember(Name = "Items")]
+        [NotNull]
+        public ObservableCollection<SourceFileExclusionFilterConfigurationItem> Items
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<ObservableCollection<SourceFileExclusionFilterConfigurationItem>>() != null);
+                CreateCollection();
+                // ReSharper disable once AssignNullToNotNullAttribute
+                return _items;
+            }
+        }
+
+        public event EventHandler<PropertyChangedEventArgs> ItemPropertyChanged
+        {
+            add
+            {
+                CreateCollection();
+                // ReSharper disable once PossibleNullReferenceException
+                _changeTracker.ItemPropertyChanged += value;
+            }
+            remove
+            {
+                CreateCollection();
+                // ReSharper disable once PossibleNullReferenceException
+                _changeTracker.ItemPropertyChanged -= value;
+            }
+        }
+
+        [NotNull]
+        public static SourceFileExclusionFilterConfiguration Default
+        {
+            get
+            {
+                Contract.Ensures(Contract.Result<SourceFileExclusionFilterConfiguration>() != null);
+
+                var value = new SourceFileExclusionFilterConfiguration();
+
+                value.Add(@"Migrations\\\d{15}");
+
+                return value;
+            }
+        }
+
+        private void Add(string expression)
+        {
+            Items.Add(
+                new SourceFileExclusionFilterConfigurationItem
+                {
+                    Expression = expression
+                });
+        }
+
+        private void CreateCollection()
+        {
+            Contract.Ensures(_items != null);
+            Contract.Ensures(_changeTracker != null);
+
+            if (_items != null)
+                return;
+
+            _items = new ObservableCollection<SourceFileExclusionFilterConfigurationItem>();
+            _changeTracker = new ObservablePropertyChangeTracker<SourceFileExclusionFilterConfigurationItem>(_items);
+        }
+
+        [ContractInvariantMethod]
+        [SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Required for code contracts.")]
+        [Conditional("CONTRACTS_FULL")]
+        private void ObjectInvariant()
+        {
+            Contract.Invariant((_items == null) || (_changeTracker != null));
+        }
+    }
+}

--- a/ResXManager.Scripting/SourceFilesProvider.cs
+++ b/ResXManager.Scripting/SourceFilesProvider.cs
@@ -3,7 +3,10 @@ namespace ResXManager.Scripting
     using System;
     using System.Collections.Generic;
     using System.ComponentModel.Composition;
+    using System.Diagnostics.Contracts;
     using System.IO;
+
+    using JetBrains.Annotations;
 
     using tomenglertde.ResXManager.Model;
 
@@ -11,6 +14,17 @@ namespace ResXManager.Scripting
     [Export(typeof(ISourceFilesProvider))]
     internal class SourceFilesProvider : ISourceFilesProvider, ISourceFileFilter
     {
+        [NotNull]
+        private readonly Configuration _configuration;
+
+        [ImportingConstructor]
+        public SourceFilesProvider([NotNull] Configuration configuration)
+        {
+            Contract.Requires(configuration != null);
+
+            _configuration = configuration;
+        }
+
         public string Folder { get; set; }
 
         public IList<ProjectFile> SourceFiles
@@ -21,7 +35,7 @@ namespace ResXManager.Scripting
                 if (String.IsNullOrEmpty(folder))
                     return new ProjectFile[0];
 
-                return new DirectoryInfo(folder).GetAllSourceFiles(this);
+                return new DirectoryInfo(folder).GetAllSourceFiles(_configuration, this);
             }
         }
 

--- a/ResXManager.View/Properties/Resources.Designer.cs
+++ b/ResXManager.View/Properties/Resources.Designer.cs
@@ -1011,6 +1011,17 @@ namespace tomenglertde.ResXManager.View.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Source file exclusion filters.
+        /// </summary>
+        [NotNull]
+        public static string SourceFileExclusionFilters_Header {
+            get {
+                Contract.Ensures(Contract.Result<string>() != null);
+                return ResourceManager.GetString("SourceFileExclusionFilters_Header", resourceCulture) ?? string.Empty;
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to ResX Resource Manager.
         /// </summary>
         /// <remarks>
@@ -1474,6 +1485,10 @@ namespace tomenglertde.ResXManager.View.Properties {
         ///   Looks up a localized string similar to Do you want to sort all nodes of all resource file....
         /// </summary>
         SortNodesByKey_Confirmation,
+        /// <summary>
+        ///   Looks up a localized string similar to Source file exclusion filters.
+        /// </summary>
+        SourceFileExclusionFilters_Header,
         /// <summary>
         ///   Looks up a localized string similar to ResX Resource Manager.
         /// </summary>

--- a/ResXManager.View/Properties/Resources.de.resx
+++ b/ResXManager.View/Properties/Resources.de.resx
@@ -401,4 +401,7 @@ Z.B. ".* - (?!Migrations)" um EF Migrationsdateien auszublenden.</value>
   <data name="UnloadSnapshot" xml:space="preserve">
     <value>Snapshot entladen</value>
   </data>
+  <data name="SourceFileExclusionFilters_Header" xml:space="preserve">
+    <value>*Source file exclusion filters</value>
+  </data>
 </root>

--- a/ResXManager.View/Properties/Resources.resx
+++ b/ResXManager.View/Properties/Resources.resx
@@ -410,4 +410,7 @@ Use e.g. ".* - (?!Migrations)" to hide EF migrations.</value>
   <data name="UnloadSnapshot" xml:space="preserve">
     <value>Unload Snapshot</value>
   </data>
+  <data name="SourceFileExclusionFilters_Header" xml:space="preserve">
+    <value>Source file exclusion filters</value>
+  </data>
 </root>

--- a/ResXManager.View/Visuals/ConfigurationEditorView.xaml
+++ b/ResXManager.View/Visuals/ConfigurationEditorView.xaml
@@ -152,9 +152,9 @@
       <Decorator Height="5" />
 
       <GroupBox Header="{x:Static properties:Resources.Diagnostics}" Style="{StaticResource GroupStyle}">
-        <CheckBox Margin="10" 
+        <CheckBox Margin="10"
                   Style="{StaticResource {x:Static styles:ResourceKeys.CheckBoxStyle}}"
-                  Content="{x:Static properties:Resources.ShowPerformanceTraces}" 
+                  Content="{x:Static properties:Resources.ShowPerformanceTraces}"
                   IsChecked="{Binding Configuration.ShowPerformanceTraces}"/>
       </GroupBox>
 
@@ -175,6 +175,22 @@
             <dgx:ExtendedStarSizeBehavior ResourceLocator="{StaticResource ResourceLocator}" />
           </i:Interaction.Behaviors>
         </DataGrid>
+      </GroupBox>
+
+      <Decorator Height="5" />
+
+      <GroupBox Header="{x:Static properties:Resources.SourceFileExclusionFilters_Header}" Style="{StaticResource GroupStyle}">
+          <DataGrid ItemsSource="{Binding Configuration.SourceFileExclusionFilters.Items}"
+              AutoGenerateColumns="False" CanUserReorderColumns="False" CanUserResizeRows="False"
+              Style="{DynamicResource {x:Static styles:ResourceKeys.DataGridStyle}}"
+              Margin="10" MinHeight="50" MaxHeight="250" MinWidth="700">
+              <DataGrid.Columns>
+                  <DataGridTextColumn Header="{x:Static properties:Resources.RegularExpression}" Binding="{Binding Expression}" Width="5*" />
+              </DataGrid.Columns>
+              <i:Interaction.Behaviors>
+                  <dgx:ExtendedStarSizeBehavior ResourceLocator="{StaticResource ResourceLocator}" />
+              </i:Interaction.Behaviors>
+          </DataGrid>
       </GroupBox>
 
       <ItemsControl toms:VisualComposition.RegionId="{x:Static infrastructure:RegionId.Configuration}">

--- a/ResXManager/MainViewModel.cs
+++ b/ResXManager/MainViewModel.cs
@@ -273,7 +273,7 @@
                 if (string.IsNullOrEmpty(folder))
                     return new ProjectFile[0];
 
-                return new DirectoryInfo(folder).GetAllSourceFiles(new SourceFileFilter(_configuration));
+                return new DirectoryInfo(folder).GetAllSourceFiles(_configuration, new SourceFileFilter(_configuration));
             }
         }
 


### PR DESCRIPTION
This PR adds a new configurable option which allows users to exclude source files from being processed as soon as possible.
As soon as possible means from the moment they were found somewhere in the solution folder but before they are being added as a `ProjectFile` inside the `ResourceManagerExtensions.GetAllSourceFiles(...)` extension method.

Why this option? 

I've seen a few issues on Codeplex describing the problems with resx files being part of Entity Framework migrations that are shown in the list of files containing resources ...
- [ResX exclude Files/Paths](https://resxresourcemanager.codeplex.com/workitem/4782)
- [Auto exclude EF code first migration resources](https://resxresourcemanager.codeplex.com/workitem/4617)

The suggestion is to filter them out based on a regular expression like `.* - (?!Migrations\\d{15})` or just `Migrations` etc...
Now even though this suggestion works as expected, it still means that we need to specify this one again once we used another filter (to get another specific file) etc... and most of the time we just don't want to see those Entity Framework Migration resource files popping up anywhere in the application and have to filter them out so we can see the "real" resource files we are interested in.

When I saw the filter suggestion in the above issues, I kept on looking where to specify this one in the configuration, but instead I had to use it in the filter box which was not what I was looking for...

Therefore this PR will make it possible to specify regular expressions to exclude source files from the very first moment they are "detected" by the application, so that no manual filtering must be done later because those files will never be treated as `ProjectFile`s. It might even give some performance gains, but that would just be a side-effect of having less `ProjectFile`s to process, most likely negligible but in big projects it might actually be noticeable.

The PR is not complete in the sense, that the German translation for the configuration option needs to be set ;-) 

I create a PR instead of a Patch on Codeplex, but if you rather want to see a patch, then I will try to make one

Best regards
Christophe
