### PR TITLE
Standalone Installer does not work when AutoProperties are not in the GAC

### DIFF
--- a/ResXManager/ResXManager.csproj
+++ b/ResXManager/ResXManager.csproj
@@ -179,7 +179,7 @@
   <ItemGroup>
     <Reference Include="AutoProperties, Version=1.6.0.0, Culture=neutral, PublicKeyToken=4d0e9a1cbec0d397, processorArchitecture=MSIL">
       <HintPath>..\packages\AutoProperties.Fody.1.6.0.0\lib\netstandard1.0\AutoProperties.dll</HintPath>
-      <Private>False</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="JetBrains.Annotations, Version=11.0.0.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
       <HintPath>..\packages\JetBrains.Annotations.11.0.0\lib\net20\JetBrains.Annotations.dll</HintPath>


### PR DESCRIPTION
Hey you!
Thank you for your great extension. Our Business Analyst wants to modify the resourcefiles himself but has no visual studio. So he tried to install ResXManager as Standalone Application. This fails with the error in the attachment.

![dfsvc_2017-10-24_11-32-22](https://user-images.githubusercontent.com/7276477/31935402-0900aed8-b8af-11e7-9542-a4c901648e71.png)

I followed this site to fix the bug:
[https://ablogontech.wordpress.com/2009/01/02/unable-to-install-or-run-the-application-the-application-requires-that-the-assembly-be-installed-in-the-global-assembly-cache-gac-first/](https://ablogontech.wordpress.com/2009/01/02/unable-to-install-or-run-the-application-the-application-requires-that-the-assembly-be-installed-in-the-global-assembly-cache-gac-first/)

So i set Copy Local to true for the AutoProperties Assembly in the project properties of the ResXManager WPF project. I created a local publish package, tried to install it and now it works 👍. 
