### PR TITLE
GoogleTranslator.cs translation model update

### DIFF
--- a/ResXManager.Translators/GoogleTranslator.cs
+++ b/ResXManager.Translators/GoogleTranslator.cs
@@ -80,7 +80,7 @@
                             "target", GoogleLangCode(targetCulture),
                             "format", "text",
                             "source", GoogleLangCode(translationSession.SourceLanguage),
-                            "model", "base",
+                            "model", "nmt",
                             "key", ApiKey });
 
                         try


### PR DESCRIPTION
As per https://cloud.google.com/translate/docs/basic/translating-text#using_the_model_parameter

"Specifying a model
By default, when you make a translation request to the Cloud Translation API, your text is translated using the Neural Machine Translation (NMT) model. If the NMT model is not supported for the requested language translation pair, then the Phrase-Based Machine Translation (PBMT) model is used.

Comparing models
The NMT model can provide improved translation for longer and more complex content. For example, consider the following request"

My personal experience is that this produces similar results to online/web translation and is seemingly much more accurate/predictable. Another option would be removing model parameter (which per documentation defaults to nmt anyway) however I have not tested this yet.